### PR TITLE
add grok 3.0.1 support (use grok.implementer instead of grok.implements)

### DIFF
--- a/uvc/unfallanzeige/interfaces.py
+++ b/uvc/unfallanzeige/interfaces.py
@@ -70,8 +70,8 @@ class IPresentation(Interface):
     """ Marker Interface """
 
 
+@grok.implementer(IContextSourceBinder)
 class DynVocab(object):
-    grok.implements(IContextSourceBinder)
 
     def __init__(self, name):
         self.name = name


### PR DESCRIPTION
Due to python 3 support the grok.implements directive has to be replaced
with the decorator grok.implementer.