### PR TITLE
Fix bugs in template basic.cpt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(name='uvc.unfallanzeige',
       install_requires=[
           'setuptools',
           'reportlab',
+          'uvc.tbskin >= 0.7.2',
           # -*- Extra requirements: -*-
       ],
       entry_points={

--- a/uvc/unfallanzeige/templates/basic.cpt
+++ b/uvc/unfallanzeige/templates/basic.cpt
@@ -20,7 +20,7 @@
        <div class="row">
 	 <div class="col-md-8">
      <div class="form-group col-md-8" 
-       tal:define="widget W.get('form.basic.field.unfustrasse'); widget2 W.get('form.basic.field.unfunr)" metal:use-macro="view.macros['doublefield']">
+       tal:define="widget W.get('form.basic.field.unfustrasse'); widget2 W.get('form.basic.field.unfunr')" metal:use-macro="view.macros['doublefield']">
 	   </div>
 	 </div>
        </div>


### PR DESCRIPTION
- Fix: String literal not closed in expression

- Fix: macro 'doublefield' is not defined
   Add dependency uvc.tbskin >= 0.7.2 to make sure the doublefield macro is defiend.